### PR TITLE
chore(deps): bump antelope deps to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.3",
-    "@antelopejs/interface-auth": "^0.0.4",
-    "@antelopejs/interface-core": "^0.0.3",
-    "@antelopejs/interface-data-api": "^0.1.2",
-    "@antelopejs/interface-database": "^0.1.1",
-    "@antelopejs/interface-database-decorators": "^0.1.2"
+    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-auth": "^0.0.5",
+    "@antelopejs/interface-core": "^0.0.6",
+    "@antelopejs/interface-data-api": "^0.1.4",
+    "@antelopejs/interface-database": "^0.1.3",
+    "@antelopejs/interface-database-decorators": "^0.1.3"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-auth':
-        specifier: ^0.0.4
-        version: 0.0.4
+        specifier: ^0.0.5
+        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.6
+        version: 0.0.6
       '@antelopejs/interface-data-api':
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.1.4
+        version: 0.1.4(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
       '@antelopejs/interface-database':
-        specifier: ^0.1.1
-        version: 0.1.1
+        specifier: ^0.1.3
+        version: 0.1.3(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-database-decorators':
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^0.1.3
+        version: 0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -42,20 +42,43 @@ packages:
   '@antelopejs/interface-api@0.0.3':
     resolution: {integrity: sha512-64UrrttRAjA1LsXwDskh/UVcXDFpH2+gxJHCT+F8YGLPDJE1XzVUW6/YeG441J+zsFJTnaU6Vlt90TwWumcpCA==}
 
-  '@antelopejs/interface-auth@0.0.4':
-    resolution: {integrity: sha512-PubP0n2x5Migr8zYHmgi8t6Ymce3bRNKJiN4l7fpoO2rx5Jx1i/SQsKKfqDRcotVLitUoe8pyWa35Cy44tyA+Q==}
+  '@antelopejs/interface-api@0.0.5':
+    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+
+  '@antelopejs/interface-auth@0.0.5':
+    resolution: {integrity: sha512-/WGlwVcERMRuZApv23VQO0158VXAzsxfPA6ZWSJEJnWHwAkjfw+6UkkDGC46ylIl0/He0OjBnzuSehf1ONVHnw==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@antelopejs/interface-core@0.0.3':
     resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
 
-  '@antelopejs/interface-data-api@0.1.2':
-    resolution: {integrity: sha512-1dZe1iz2eB4ySwivDcJfzOmoXh5tn16i+hCEdmWSog7Bpg2m4Utj6UjeVSAWj9Rq/6uGhwr5W4X/liGoLK/5Pg==}
+  '@antelopejs/interface-core@0.0.6':
+    resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
-  '@antelopejs/interface-database-decorators@0.1.2':
-    resolution: {integrity: sha512-WEB88PbxpouoiFaoLnoa7AWP4F+tSTlC4MwVHaYchVTbNcszLSqeQA5z4DgsIKMn3Ri2/tus6NWTl+NcDgw36A==}
+  '@antelopejs/interface-data-api@0.1.4':
+    resolution: {integrity: sha512-4RqJ2dVB/HfvDDFdEShaQUSSltGJviPwagCqsIr27BkK/vfY+S/5NyShboGFBVzxB4wzL4SXu35Z4mtCpdV8tw==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-api-util': '>=0.0.4 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-database': '>=0.1.2 <1.0.0'
+      '@antelopejs/interface-database-decorators': '>=0.1.1 <1.0.0'
 
-  '@antelopejs/interface-database@0.1.1':
-    resolution: {integrity: sha512-b2/fgLhDVSTbr3tXIpKCfnpCGxy2Jwf2qbMPOJ1lxru+ut7ipDbdnNhWbS+doY2BRICuFuJ/IOiRiWYTOrsBsg==}
+  '@antelopejs/interface-database-decorators@0.1.3':
+    resolution: {integrity: sha512-yPSP7cYh/7nhj1y2bOWvJ1idErWqI4EsYppVg3XOy7KEaZ+RvKodwFYDle0dqsFp9UNtR8p3m0bg0YasZrAayA==}
+    peerDependencies:
+      '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
+      '@antelopejs/interface-database': '>=0.1.1 <1.0.0'
+
+  '@antelopejs/interface-database@0.1.3':
+    resolution: {integrity: sha512-tMMrQz0IFz1m82O6vYMU9Jbr2x4ZV/nTwBoViONrDuSZrJona3M1lglFh2F6ltS4LaJTsoUXr+qZGupPz2TGaA==}
+    peerDependencies:
+      '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -92,34 +115,42 @@ snapshots:
     dependencies:
       '@antelopejs/interface-core': 0.0.3
 
-  '@antelopejs/interface-auth@0.0.4':
+  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.3
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.6
+
+  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
+    dependencies:
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-core': 0.0.6
 
   '@antelopejs/interface-core@0.0.3':
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-data-api@0.1.2':
+  '@antelopejs/interface-core@0.0.6':
     dependencies:
-      '@antelopejs/interface-api': 0.0.3
-      '@antelopejs/interface-api-util': 0.0.4
-      '@antelopejs/interface-core': 0.0.3
-      '@antelopejs/interface-database': 0.1.1
-      '@antelopejs/interface-database-decorators': 0.1.2
+      reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database-decorators@0.1.2':
+  '@antelopejs/interface-data-api@0.1.4(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
     dependencies:
-      '@antelopejs/interface-api': 0.0.3
-      '@antelopejs/interface-core': 0.0.3
-      '@antelopejs/interface-database': 0.1.1
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-api-util': 0.0.4
+      '@antelopejs/interface-core': 0.0.6
+      '@antelopejs/interface-database': 0.1.3(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-database-decorators': 0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
+
+  '@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
+    dependencies:
+      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-core': 0.0.6
+      '@antelopejs/interface-database': 0.1.3(@antelopejs/interface-core@0.0.6)
       randomstring: 1.3.1
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.1.1':
+  '@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-core': 0.0.3
+      '@antelopejs/interface-core': 0.0.6
 
   '@types/node@22.19.15':
     dependencies:


### PR DESCRIPTION
Bump `@antelopejs/interface-*` (and core) to latest. Template/leaf project: interfaces stay in `dependencies`. Verified: install + build.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps all six `@antelopejs/interface-*` (and core) dependencies to their latest versions. The lockfile is updated consistently, and pnpm's `autoInstallPeers: true` setting resolves the new `@antelopejs/interface-api-util` peer dependency introduced by `interface-data-api@0.1.4`.

- **Dependency versions bumped**: `interface-api` 0.0.3→0.0.5, `interface-auth` 0.0.4→0.0.5, `interface-core` 0.0.3→0.0.6, `interface-data-api` 0.1.2→0.1.4, `interface-database` 0.1.1→0.1.3, `interface-database-decorators` 0.1.2→0.1.3.
- **New implicit peer dep**: `interface-data-api@0.1.4` now requires `@antelopejs/interface-api-util` as a peer; pnpm auto-installs it at `0.0.4` (the minimum), which transitively brings back `interface-api@0.0.3` and `interface-core@0.0.3` alongside the new versions.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one minor follow-up: explicitly declare `@antelopejs/interface-api-util` in `package.json` to avoid a phantom dependency.

The version bumps are consistent between `package.json` and the lockfile, and the build was verified. The only concern is that `interface-data-api@0.1.4` introduced `@antelopejs/interface-api-util` as a peer dependency that pnpm silently auto-installs at the minimum version `0.0.4`. That version internally depends on `interface-api@0.0.3` and `interface-core@0.0.3`, leaving two older copies of those packages in the install tree alongside the updated ones.

`package.json` — should explicitly declare `@antelopejs/interface-api-util` since it became a peer dep of `interface-data-api@0.1.4`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| package.json | All six `@antelopejs/interface-*` dependencies bumped to latest; `@antelopejs/interface-api-util` is now a peer dep of `interface-data-api@0.1.4` but is missing from this file — auto-resolved by pnpm's `autoInstallPeers` at v0.0.4 (which pulls stale transitive versions). |
| pnpm-lock.yaml | Lockfile correctly updated for all bumped packages; retains `@antelopejs/interface-api@0.0.3` and `@antelopejs/interface-core@0.0.3` because `@antelopejs/interface-api-util@0.0.4` (auto-installed peer) depends on them. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    proj["package.json\n(project)"]

    proj -->|dep| api["interface-api\n0.0.3 → 0.0.5"]
    proj -->|dep| auth["interface-auth\n0.0.4 → 0.0.5"]
    proj -->|dep| core["interface-core\n0.0.3 → 0.0.6"]
    proj -->|dep| dataapi["interface-data-api\n0.1.2 → 0.1.4"]
    proj -->|dep| db["interface-database\n0.1.1 → 0.1.3"]
    proj -->|dep| dbdec["interface-database-decorators\n0.1.2 → 0.1.3"]

    dataapi -->|peer dep - NEW| apiutil["interface-api-util\n0.0.4 (auto-installed)"]

    apiutil -. "depends on old versions" .-> api_old["interface-api@0.0.3 (retained)"]
    apiutil -. "depends on old versions" .-> core_old["interface-core@0.0.3 (retained)"]

    style apiutil fill:#ffe0b2,stroke:#e65100
    style api_old fill:#ffccbc,stroke:#bf360c
    style core_old fill:#ffccbc,stroke:#bf360c
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    proj["package.json\n(project)"]

    proj -->|dep| api["interface-api\n0.0.3 → 0.0.5"]
    proj -->|dep| auth["interface-auth\n0.0.4 → 0.0.5"]
    proj -->|dep| core["interface-core\n0.0.3 → 0.0.6"]
    proj -->|dep| dataapi["interface-data-api\n0.1.2 → 0.1.4"]
    proj -->|dep| db["interface-database\n0.1.1 → 0.1.3"]
    proj -->|dep| dbdec["interface-database-decorators\n0.1.2 → 0.1.3"]

    dataapi -->|peer dep - NEW| apiutil["interface-api-util\n0.0.4 (auto-installed)"]

    apiutil -. "depends on old versions" .-> api_old["interface-api@0.0.3 (retained)"]
    apiutil -. "depends on old versions" .-> core_old["interface-core@0.0.3 (retained)"]

    style apiutil fill:#ffe0b2,stroke:#e65100
    style api_old fill:#ffccbc,stroke:#bf360c
    style core_old fill:#ffccbc,stroke:#bf360c
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
package.json:9-16
**Implicit peer dependency on `@antelopejs/interface-api-util`**

`@antelopejs/interface-data-api@0.1.4` added `@antelopejs/interface-api-util: '>=0.0.4 <1.0.0'` as a new peer dependency, but this package is absent from `package.json`. pnpm's `autoInstallPeers: true` silently resolves it to `0.0.4` — the minimum version allowed. That version internally depends on `@antelopejs/interface-api@0.0.3` and `@antelopejs/interface-core@0.0.3`, so two extra copies of those older packages land in the final install (visible in the lockfile snapshots at lines 109-116). Explicitly adding `"@antelopejs/interface-api-util": "^0.0.4"` to `dependencies` makes the choice intentional, allows deliberate version management, and avoids the phantom-dependency pattern.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump antelope deps to lates..."](https://github.com/antelopejs/template-todo-typescript/commit/bfa1d1d0063480157e53b27e24370981236a392c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37959508)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->