### PR TITLE
feat: declare table fields with @Field decorator

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "dev": "ajs project run -w"
   },
   "dependencies": {
-    "@antelopejs/interface-api": "^0.0.5",
+    "@antelopejs/interface-api": "^0.0.7",
     "@antelopejs/interface-auth": "^0.0.5",
     "@antelopejs/interface-core": "^0.0.6",
-    "@antelopejs/interface-data-api": "^0.1.4",
+    "@antelopejs/interface-data-api": "^0.1.5",
     "@antelopejs/interface-database": "^0.1.3",
-    "@antelopejs/interface-database-decorators": "^0.1.3"
+    "@antelopejs/interface-database-decorators": "^0.1.4"
   },
   "devDependencies": {
     "@types/node": "^22.19.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,23 +9,23 @@ importers:
   .:
     dependencies:
       '@antelopejs/interface-api':
-        specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-core@0.0.6)
+        specifier: ^0.0.7
+        version: 0.0.7(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-auth':
         specifier: ^0.0.5
-        version: 0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
+        version: 0.0.5(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core':
         specifier: ^0.0.6
         version: 0.0.6
       '@antelopejs/interface-data-api':
-        specifier: ^0.1.4
-        version: 0.1.4(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
+        specifier: ^0.1.5
+        version: 0.1.5(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.4(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
       '@antelopejs/interface-database':
         specifier: ^0.1.3
         version: 0.1.3(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-database-decorators':
-        specifier: ^0.1.3
-        version: 0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
+        specifier: ^0.1.4
+        version: 0.1.4(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
     devDependencies:
       '@types/node':
         specifier: ^22.19.15
@@ -42,8 +42,8 @@ packages:
   '@antelopejs/interface-api@0.0.3':
     resolution: {integrity: sha512-64UrrttRAjA1LsXwDskh/UVcXDFpH2+gxJHCT+F8YGLPDJE1XzVUW6/YeG441J+zsFJTnaU6Vlt90TwWumcpCA==}
 
-  '@antelopejs/interface-api@0.0.5':
-    resolution: {integrity: sha512-BApviHE1vVkORDWtC8x8N2xCxBdFZZnhgMlxDuUmlXz2fGlYqBX1inIQQrEyOY31Zc/WN7nJpcA0zjjwk7Sp9A==}
+  '@antelopejs/interface-api@0.0.7':
+    resolution: {integrity: sha512-RaepQjtHJsXMvr5+bNT8UA/BnZJn63PsdXWl010QeImONdf9vczlXX55oCh/kjo5lS2RdCa33YaF/gvTqo2Ikg==}
     peerDependencies:
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
 
@@ -59,8 +59,8 @@ packages:
   '@antelopejs/interface-core@0.0.6':
     resolution: {integrity: sha512-OMna86iT/ylL6wJl6FCPw9ieddULXGs4jTmeiDBNEXYQ9acnVXjS/+SaN0UR0h7oY7WTD9VwKXVwG95qjNIA1w==}
 
-  '@antelopejs/interface-data-api@0.1.4':
-    resolution: {integrity: sha512-4RqJ2dVB/HfvDDFdEShaQUSSltGJviPwagCqsIr27BkK/vfY+S/5NyShboGFBVzxB4wzL4SXu35Z4mtCpdV8tw==}
+  '@antelopejs/interface-data-api@0.1.5':
+    resolution: {integrity: sha512-heyfovI1VTtg+hUFvqshFRUgypqvcttIC4SelXEMtvAqtOZ7l+22UAYEwDpgdJ0mCRPMbUBaoVg3ioyrrUiTTg==}
     peerDependencies:
       '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
       '@antelopejs/interface-api-util': '>=0.0.4 <1.0.0'
@@ -68,8 +68,8 @@ packages:
       '@antelopejs/interface-database': '>=0.1.2 <1.0.0'
       '@antelopejs/interface-database-decorators': '>=0.1.1 <1.0.0'
 
-  '@antelopejs/interface-database-decorators@0.1.3':
-    resolution: {integrity: sha512-yPSP7cYh/7nhj1y2bOWvJ1idErWqI4EsYppVg3XOy7KEaZ+RvKodwFYDle0dqsFp9UNtR8p3m0bg0YasZrAayA==}
+  '@antelopejs/interface-database-decorators@0.1.4':
+    resolution: {integrity: sha512-jjy0ZGH7sBcuPQpsa6jdsYCzg1WzmrA/QS0nqSdrBWsHVOBVEVXgFG1LJLduEgb8WcJrN75rVZUiYebgT6cSag==}
     peerDependencies:
       '@antelopejs/interface-api': '>=0.0.3 <1.0.0'
       '@antelopejs/interface-core': '>=0.0.3 <1.0.0'
@@ -115,13 +115,13 @@ snapshots:
     dependencies:
       '@antelopejs/interface-core': 0.0.3
 
-  '@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6)':
+  '@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6)':
     dependencies:
       '@antelopejs/interface-core': 0.0.6
 
-  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
+  '@antelopejs/interface-auth@0.0.5(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)':
     dependencies:
-      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-api': 0.0.7(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core': 0.0.6
 
   '@antelopejs/interface-core@0.0.3':
@@ -132,17 +132,17 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-data-api@0.1.4(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
+  '@antelopejs/interface-data-api@0.1.5(@antelopejs/interface-api-util@0.0.4)(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database-decorators@0.1.4(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6)))(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
     dependencies:
-      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-api': 0.0.7(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-api-util': 0.0.4
       '@antelopejs/interface-core': 0.0.6
       '@antelopejs/interface-database': 0.1.3(@antelopejs/interface-core@0.0.6)
-      '@antelopejs/interface-database-decorators': 0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
+      '@antelopejs/interface-database-decorators': 0.1.4(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))
 
-  '@antelopejs/interface-database-decorators@0.1.3(@antelopejs/interface-api@0.0.5(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
+  '@antelopejs/interface-database-decorators@0.1.4(@antelopejs/interface-api@0.0.7(@antelopejs/interface-core@0.0.6))(@antelopejs/interface-core@0.0.6)(@antelopejs/interface-database@0.1.3(@antelopejs/interface-core@0.0.6))':
     dependencies:
-      '@antelopejs/interface-api': 0.0.5(@antelopejs/interface-core@0.0.6)
+      '@antelopejs/interface-api': 0.0.7(@antelopejs/interface-core@0.0.6)
       '@antelopejs/interface-core': 0.0.6
       '@antelopejs/interface-database': 0.1.3(@antelopejs/interface-core@0.0.6)
       randomstring: 1.3.1

--- a/src/db/tables/task.table.ts
+++ b/src/db/tables/task.table.ts
@@ -1,20 +1,26 @@
-import { Table, Index, RegisterTable } from '@antelopejs/interface-database-decorators';
+import { Table, Field, Index, RegisterTable } from '@antelopejs/interface-database-decorators';
 
 /**
  * Task table definition with title, description and userId fields
  */
 @RegisterTable('tasks', 'default')
 export class Task extends Table {
+  @Field('string')
   declare _id: string;
 
+  @Field('string')
   declare title: string;
 
+  @Field('string')
   declare description: string;
 
   @Index()
+  @Field('string')
   declare userId: string;
 
+  @Field('date')
   declare createdAt: Date;
 
+  @Field('date')
   declare updatedAt: Date;
 }

--- a/src/db/tables/task.table.ts
+++ b/src/db/tables/task.table.ts
@@ -1,4 +1,5 @@
-import { Table, Field, Index, RegisterTable } from '@antelopejs/interface-database-decorators';
+import { Table, Field, Index, Relation, RegisterTable } from '@antelopejs/interface-database-decorators';
+import { User } from './user.table';
 
 /**
  * Task table definition with title, description and userId fields
@@ -14,6 +15,7 @@ export class Task extends Table {
   @Field('string')
   declare description: string;
 
+  @Relation({ to: () => User })
   @Index()
   @Field('string')
   declare userId: string;

--- a/src/db/tables/user.table.ts
+++ b/src/db/tables/user.table.ts
@@ -1,19 +1,24 @@
-import { Table, Index, HashModifier, Hashed, RegisterTable } from '@antelopejs/interface-database-decorators';
+import { Table, Field, Index, HashModifier, Hashed, RegisterTable } from '@antelopejs/interface-database-decorators';
 
 /**
  * User table definition with basic user fields
  */
 @RegisterTable('users', 'default')
 export class User extends Table.with(HashModifier) {
+  @Field('string')
   declare _id: string;
 
   @Index()
+  @Field('string')
   declare email: string;
 
   @Hashed()
+  @Field('string')
   declare password: string;
 
+  @Field('date')
   declare createdAt: Date;
 
+  @Field('date')
   declare updatedAt: Date;
 }


### PR DESCRIPTION
## Contexte

Les tables `Task` et `User` du template déclaraient leurs propriétés avec un simple `declare` en n'annotant que les index (`@Index`). Or, avec l'API actuelle de `interface-database-decorators`, **toute propriété sans `@Field` est omise de `TableDefinition.fields`** (cf. doc `2.table-definitions.md` : *« Properties without `@Field` are omitted from `fields` »*).

Résultat en l'état : aucune colonne (`title`, `description`, `email`, `password`, timestamps…) ne serait provisionnée dans le schéma.

## Changement

Ajout de `@Field(type)` sur chaque propriété persistée des deux tables, en suivant exactement le pattern déjà utilisé et validé dans `template-cms-demo` :

- `task.table.ts` : `@Field('string')` sur `_id`, `title`, `description`, `userId` ; `@Field('date')` sur `createdAt`, `updatedAt`.
- `user.table.ts` : idem, avec `@Index() @Field('string')` sur `email` et `@Hashed() @Field('string')` sur `password`.

Les `@Index`, `@Hashed` et `@RegisterTable` existants sont conservés. Aucun changement côté `models/`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds missing `@Field(type)` decorators to all persisted properties in the `Task` and `User` table definitions. Without them, the database adapter receives an empty `TableDefinition.fields` map and provisions no columns at all.

- `task.table.ts`: `@Field('string')` added to `_id`, `title`, `description`, `userId`; `@Field('date')` to `createdAt` and `updatedAt`. Existing `@Index()` on `userId` is preserved and stacked correctly.
- `user.table.ts`: Same treatment, with `@Index() @Field('string')` on `email` and `@Hashed() @Field('string')` on `password` — both matching the decorator-stacking order validated in the upstream library's own documentation examples.

<h3>Confidence Score: 5/5</h3>

Both table files are straightforward decorator additions with no logic changes — safe to merge.

The change is minimal and mechanical: each persisted property now carries the @Field(type) decorator required by the library to include it in the schema provisioning map. Decorator stacking order (@Index() / @Hashed() above @Field()) matches the upstream library's own documented examples exactly. No model, route, or business logic is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/db/tables/task.table.ts | Adds @Field('string') to _id, title, description, userId and @Field('date') to createdAt/updatedAt; all decorator stacking is consistent with upstream docs. |
| src/db/tables/user.table.ts | Adds @Field('string') to _id, email, password and @Field('date') to createdAt/updatedAt; @Hashed() + @Field() and @Index() + @Field() ordering matches library examples. |

</details>

<h3>Entity Relationship Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    TASKS {
        string _id PK
        string title
        string description
        string userId FK
        date createdAt
        date updatedAt
    }
    USERS {
        string _id PK
        string email
        string password
        date createdAt
        date updatedAt
    }
    TASKS }o--|| USERS : "userId"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
erDiagram
    TASKS {
        string _id PK
        string title
        string description
        string userId FK
        date createdAt
        date updatedAt
    }
    USERS {
        string _id PK
        string email
        string password
        date createdAt
        date updatedAt
    }
    TASKS }o--|| USERS : "userId"
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat: declare table fields with @Field d..."](https://github.com/antelopejs/template-todo-typescript/commit/aaf5aa51b03dd4177d446984d2885353557c1ac1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42055501)</sub>

<!-- /greptile_comment -->